### PR TITLE
Fix: Default Mode

### DIFF
--- a/dca/tl_inserttags.php
+++ b/dca/tl_inserttags.php
@@ -226,7 +226,7 @@ $GLOBALS['TL_DCA']['tl_inserttags'] = array
 		'mode' => array
 		(
 			'label'						=> &$GLOBALS['TL_LANG']['tl_inserttags']['mode'],
-			'default'                   => 'fe',
+			'default'                   			=> 'FE',
 			'inputType'					=> 'radio',
 			'exclude'					=> true,
 			'filter'					=> true,


### PR DESCRIPTION
I created an insert tag and did not see it.

Then I found the expert settings - display in FE / BE.
I think there should be a default to FE because normally the expert settings are not expanded.