### PR TITLE
Run module in own namespace for contao 4.4+

### DIFF
--- a/InsertTags.php
+++ b/InsertTags.php
@@ -9,6 +9,10 @@
  * @link       http://github.com/terminal42/contao-inserttags
  */
 
+namespace InsertTags;
+
+use Contao\Frontend;
+use Contao\Controller;
 
 class InsertTags extends Frontend
 {
@@ -78,7 +82,7 @@ class InsertTags extends Frontend
                 if ($this->validateTag($arrRow)) {
                     $GLOBALS['INSERTAGS'][$strTag]++;
                     $strBuffer .= \StringUtil::parseSimpleTokens(
-                        \Controller::replaceInsertTags($arrRow['replacement'], false),
+                        Controller::replaceInsertTags($arrRow['replacement'], false),
                         $arrTag
                     );
                     break;
@@ -123,7 +127,7 @@ class InsertTags extends Frontend
                 $GLOBALS['INSERTAGS'][$strTag]++;
 
                 return \StringUtil::parseSimpleTokens(
-                    \Controller::replaceInsertTags($arrRow['replacement'], false),
+                    Controller::replaceInsertTags($arrRow['replacement'], false),
                     $arrTag
                 );
             }
@@ -173,16 +177,16 @@ class InsertTags extends Frontend
         }
 
         if ($arrRow['useCondition']) {
-            $query = \Controller::replaceInsertTags($arrRow['conditionQuery'], false);
+            $query = Controller::replaceInsertTags($arrRow['conditionQuery'], false);
 
             switch ($arrRow['conditionType']) {
                 case 'database':
                     try {
                         $query = \Database::getInstance()->execute($query)->fetchRow();
                         $query = $query[0];
-                    } catch (Exception $e) {
+                    } catch (\Exception $e) {
                         // Something went wrong with the database query. Use as text instead
-                        $query = \Controller::replaceInsertTags($arrRow['conditionQuery'], false);
+                        $query = Controller::replaceInsertTags($arrRow['conditionQuery'], false);
                     }
                     break;
             }

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -15,6 +15,6 @@
  */
 ClassLoader::addClasses(array
 (
-    'InsertTags'         => 'system/modules/inserttags/InsertTags.php',
+    'InsertTags\InsertTags'         => 'system/modules/inserttags/InsertTags.php',
 ));
 

--- a/config/config.php
+++ b/config/config.php
@@ -23,6 +23,6 @@ $GLOBALS['BE_MOD']['content']['inserttags'] = array
 /**
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['outputFrontendTemplate'][]    = array('InsertTags', 'replaceCachedTags');
-$GLOBALS['TL_HOOKS']['outputBackendTemplate'][]     = array('InsertTags', 'replaceCachedTags');
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][]         = array('InsertTags', 'replaceDynamicTags');
+$GLOBALS['TL_HOOKS']['outputFrontendTemplate'][]    = array('InsertTags\InsertTags', 'replaceCachedTags');
+$GLOBALS['TL_HOOKS']['outputBackendTemplate'][]     = array('InsertTags\InsertTags', 'replaceCachedTags');
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][]         = array('InsertTags\InsertTags', 'replaceDynamicTags');


### PR DESCRIPTION
Hi there,

i know this module is not actively maintained, but still very helpful within contao 4. If the module is not running in its own namespace within contao 4, i get the following error:

 ```
Attempted to call an undefined method named "replaceCachedTags" of class "InsertTags".
```
Was there any reason why not running in a custom namespace, or old php days?

Can you please merge this pull request? 

