### PR TITLE
Hotfix: remove no longer existing class `Inserttags` from autoload.ini

### DIFF
--- a/config/autoload.php
+++ b/config/autoload.php
@@ -15,7 +15,6 @@
  */
 ClassLoader::addClasses(array
 (
-    'InsertTags'       => 'system/modules/inserttags/InsertTags.php',
     'InsertTagsHelper' => 'system/modules/inserttags/InsertTagsHelper.php',
 ));
 


### PR DESCRIPTION
I know this repo is no longer maintained, but can you please merge this fix and create a new tag? :)

1.9.5 will throw an Exception with Contao 4.4 LTS, because the Classloader is not able to find `system/modules/inserttags/InsertTags.php`